### PR TITLE
Support new format of Consecutive Events.

### DIFF
--- a/src/simple-segment-aggregation.js
+++ b/src/simple-segment-aggregation.js
@@ -23,7 +23,7 @@ var SimpleSegmentAggregation = {
       continuesBackward;
 
     _.each(group, function(g, index) {
-      currentIds = _.pluck(g.segment, options.idAttribute);
+      currentIds = _.pluck(g.events, options.idAttribute);
       continuesBackward = false;
 
       if (index) {
@@ -53,7 +53,7 @@ var SimpleSegmentAggregation = {
       // iterations disprove, and modify, the assumption
       if (!aggregates[i]) {
         aggregates[i] = {
-          events: _.clone(g.segment),
+          events: _.clone(g.events),
           start: +g.timestamp,
           duration: 1,
           continuesForward: false,

--- a/test/fixtures/aggregation.js
+++ b/test/fixtures/aggregation.js
@@ -12,33 +12,33 @@ if (module.exports) { module.exports = fixtures.aggregation; }
 fixtures.aggregation.twoSegments = [
   {
     timestamp: 1,
-    segment: [{id: 1}, {id: 2}]
+    events: [{id: 1}, {id: 2}]
   },
   {
     timestamp: 2,
-    segment: [{id: 1}, {id: 2}]
+    events: [{id: 1}, {id: 2}]
   }
 ];
 
 fixtures.aggregation.mixed = [
   {
     timestamp: 1,
-    segment: [{id: 1}, {id: 2}]
+    events: [{id: 1}, {id: 2}]
   },
   {
     timestamp: 2,
-    segment: [{id: 1}, {id: 2}]
+    events: [{id: 1}, {id: 2}]
   },
   {
     timestamp: 3,
-    segment: [{id: 2}]
+    events: [{id: 2}]
   },
   {
     timestamp: 4,
-    segment: [{id: 3}, {id: 4}]
+    events: [{id: 3}, {id: 4}]
   },
   {
     timestamp: 5,
-    segment: [{id: 3}, {id: 4}, {id: 5}]
+    events: [{id: 3}, {id: 4}, {id: 5}]
   }
 ];

--- a/test/fixtures/no-aggregation.js
+++ b/test/fixtures/no-aggregation.js
@@ -12,21 +12,21 @@ if (module.exports) { module.exports = fixtures.noAggregation; }
 fixtures.noAggregation.noOverlap = [
   {
     timestamp: 1,
-    segment: [{id: 1}, {id: 2}]
+    events: [{id: 1}, {id: 2}]
   },
   {
     timestamp: 2,
-    segment: [{id: 3}, {id: 4}]
+    events: [{id: 3}, {id: 4}]
   }
 ];
 
 fixtures.noAggregation.someOverlap = [
   {
     timestamp: 1,
-    segment: [{id: 1}, {id: 2}]
+    events: [{id: 1}, {id: 2}]
   },
   {
     timestamp: 2,
-    segment: [{id: 2}]
+    events: [{id: 2}]
   }
 ];

--- a/test/fixtures/one-segment.js
+++ b/test/fixtures/one-segment.js
@@ -6,7 +6,7 @@ var fixtures = fixtures || {};
 
 fixtures.oneSegment = [{
   timestamp: 1,
-  segment: [{id: 1}, {id: 2}, {id: 3}]
+  events: [{id: 1}, {id: 2}, {id: 3}]
 }];
 
 var module = module || {};

--- a/test/unit/aggregation.js
+++ b/test/unit/aggregation.js
@@ -18,8 +18,8 @@ describe('Aggregation', function() {
     });
 
     it('should have the same events as in both segments', function() {
-      expect(this.aggregates[0].events).to.deep.equal(this.fixtures[0].segment);
-      expect(this.aggregates[0].events).to.deep.equal(this.fixtures[1].segment);
+      expect(this.aggregates[0].events).to.deep.equal(this.fixtures[0].events);
+      expect(this.aggregates[0].events).to.deep.equal(this.fixtures[1].events);
     });
 
     it('should not extend forward', function() {
@@ -44,7 +44,7 @@ describe('Aggregation', function() {
     it('first aggregation: should have the right properties', function() {
       expect(this.aggregates[0].duration).to.equal(2);
       expect(this.aggregates[0].start).to.equal(1);
-      expect(this.aggregates[0].events).to.deep.equal(this.fixtures[0].segment);
+      expect(this.aggregates[0].events).to.deep.equal(this.fixtures[0].events);
       expect(this.aggregates[0].continuesBackward).to.be.false;
       expect(this.aggregates[0].continuesForward).to.be.true;
     });
@@ -52,7 +52,7 @@ describe('Aggregation', function() {
     it('second aggregation: should have the right properties', function() {
       expect(this.aggregates[1].duration).to.equal(1);
       expect(this.aggregates[1].start).to.equal(3);
-      expect(this.aggregates[1].events).to.deep.equal(this.fixtures[2].segment);
+      expect(this.aggregates[1].events).to.deep.equal(this.fixtures[2].events);
       expect(this.aggregates[1].continuesBackward).to.be.true;
       expect(this.aggregates[1].continuesForward).to.be.false;
     });
@@ -60,7 +60,7 @@ describe('Aggregation', function() {
     it('third aggregation: should have the right properties', function() {
       expect(this.aggregates[2].duration).to.equal(1);
       expect(this.aggregates[2].start).to.equal(4);
-      expect(this.aggregates[2].events).to.deep.equal(this.fixtures[3].segment);
+      expect(this.aggregates[2].events).to.deep.equal(this.fixtures[3].events);
       expect(this.aggregates[2].continuesBackward).to.be.false;
       expect(this.aggregates[2].continuesForward).to.be.true;
     });
@@ -68,7 +68,7 @@ describe('Aggregation', function() {
     it('fourth aggregation: should have the right properties', function() {
       expect(this.aggregates[3].duration).to.equal(1);
       expect(this.aggregates[3].start).to.equal(5);
-      expect(this.aggregates[3].events).to.deep.equal(this.fixtures[4].segment);
+      expect(this.aggregates[3].events).to.deep.equal(this.fixtures[4].events);
       expect(this.aggregates[3].continuesBackward).to.be.true;
       expect(this.aggregates[3].continuesForward).to.be.false;
     });

--- a/test/unit/no-aggregation.js
+++ b/test/unit/no-aggregation.js
@@ -26,7 +26,7 @@ describe('No aggregation', function() {
     });
 
     it('first aggregation: contains the events from the first segment', function() {
-      expect(this.result[0].events).to.deep.equal(this.data[0].segment);
+      expect(this.result[0].events).to.deep.equal(this.data[0].events);
     });
 
     it('second aggregation: starts at 2', function() {
@@ -46,7 +46,7 @@ describe('No aggregation', function() {
     });
 
     it('second aggregation: contains the events from the first segment', function() {
-      expect(this.result[1].events).to.deep.equal(this.data[1].segment);
+      expect(this.result[1].events).to.deep.equal(this.data[1].events);
     });
   });
 
@@ -77,7 +77,7 @@ describe('No aggregation', function() {
     });
 
     it('first aggregation: contains the events from the first segment', function() {
-      expect(this.result[0].events).to.deep.equal(this.data[0].segment);
+      expect(this.result[0].events).to.deep.equal(this.data[0].events);
     });
 
     it('second aggregation: starts at 2', function() {
@@ -97,7 +97,7 @@ describe('No aggregation', function() {
     });
 
     it('second aggregation: contains the events from the first segment', function() {
-      expect(this.result[1].events).to.deep.equal(this.data[1].segment);
+      expect(this.result[1].events).to.deep.equal(this.data[1].events);
     });
   });
 });

--- a/test/unit/one-segment.js
+++ b/test/unit/one-segment.js
@@ -24,6 +24,6 @@ describe('when the group has a single segment', function() {
   });
 
   it('should return an aggregate with the same events as the segment', function() {
-    expect(this.result[0].events).to.deep.equal(fixtures.oneSegment[0].segment);
+    expect(this.result[0].events).to.deep.equal(fixtures.oneSegment[0].events);
   });
 });


### PR DESCRIPTION
Consecutive Events renamed the `segment` key to `events`. This
fix updates this library to support this new format.